### PR TITLE
Add float method

### DIFF
--- a/src/type/convert.jl
+++ b/src/type/convert.jl
@@ -5,6 +5,9 @@ macro ArbFloat(p,x)
     convert(ArbFloat{:($p)}, string(:($x)))
 end
 
+### No-Op to "convert" to float
+float(x::ArbFloat) = x
+
 # interconvert Arb with Arf
 
 function convert{P}(::Type{ArbFloat{P}}, x::ArfFloat{P})


### PR DESCRIPTION
For more robustness in a non-performance sensitive part of my codes I use `sqrt(sum(float(x).^2))` to compute an L2 norm. The float is used so that it works on integers (not type stable, but it's safe). However, it errors on ArbFloats because ArbFloats don't have a convert for this:

``` julia
LoadError: MethodError: Cannot `convert` an object of type ArbFloats.ArbFloat{116} to an object of type AbstractFloat
This may have arisen from a call to the constructor AbstractFloat(...),
since type constructors fall back to convert methods.
while loading In[11], in expression starting on line 3

 in float(::ArbFloats.ArbFloat{116}) at ./float.jl:152
 in execute_request(::ZMQ.Socket, ::IJulia.Msg) at /home/crackauc/.julia/v0.5/IJulia/src/execute_request.jl:151
 in eventloop(::ZMQ.Socket) at /home/crackauc/.julia/v0.5/IJulia/src/eventloop.jl:8
 in (::IJulia.##9#15)() at ./task.jl:360
```

BigFloat handles this as a no-op:

``` julia
float(x::BigFloat) = x
```

I think ArbFloats should add a method to do the same:

``` julia
float(x::ArbFloat) = x
```

That's the only change.
